### PR TITLE
Interim Fix for issues with stars

### DIFF
--- a/R/stars.R
+++ b/R/stars.R
@@ -1,0 +1,38 @@
+# this is just a temporal fix for an issue during subsetting stars objects with an variable that was defined not in the basenv environment
+
+"[.stars" = function(x, i = TRUE, ..., drop = FALSE, crop = TRUE) {
+    missing.i = missing(i)
+    # special case:
+    if (! missing.i && inherits(i, c("sf", "sfc", "bbox")))
+        return(st_crop(x, i, crop = crop))
+    
+    mc <- match.call(expand.dots = TRUE)
+    # select list elements from x, based on i:
+    d = attr(x, "dimensions")
+    ed = stars:::expand_dimensions.dimensions(d)
+    x = unclass(x)[i]
+    # selects also on dimensions:
+    if (length(mc) > 3) {
+        mc[[1]] <- `[`
+        if (! missing(i))
+            mc[[3]] <- NULL # remove i
+        mc[["drop"]] = FALSE
+        for (i in names(x)) {
+            mc[[2]] = as.name(i)
+            x[[i]] = eval(mc, x, enclos = parent.frame())
+        }
+        mc0 = mc[1:3] # "[", x, first dim
+        j = 3 # first dim
+        for (i in names(d)) {
+            mc0[[2]] = as.name(i)
+            mc0[[3]] = mc[[j]]
+            mc0[["values"]] = ed[[i]]
+            d[[i]] = eval(mc0, d, enclos = parent.frame())
+            j = j + 1
+        }
+    }
+    if (drop)
+        adrop(st_as_stars(x, dimensions = d))
+    else
+        st_as_stars(x, dimensions = d)
+}

--- a/man/run_UDF.Rd
+++ b/man/run_UDF.Rd
@@ -4,8 +4,8 @@
 \alias{run_UDF}
 \title{Run an UDF on a `stars` object}
 \usage{
-run_UDF(legend_name, function_name, drop_dim, in_dim = c(1, 1, 1, 1, 1),
-  out_dir = "results")
+run_UDF(legend_name = "legend.csv", function_name, drop_dim, in_dim = c(1,
+  1, 1, 1, 1), out_dir = "results")
 }
 \arguments{
 \item{legend_name}{Name of the legend file as a string}


### PR DESCRIPTION
I debugged the UDF workflow in the [Open-EO/openeo-r-backend](https://github.com/Open-EO/openeo-r-backend) and there was a problem in the stars package, when we subset the stars object from an environment that is not the baseenv, then we don't see variables outside the object, e.g. the band index.

For now, until it is fixed in the stars package we overwrite the `[.stars` function with a slightly modified version, where we extend the envionment scope to the parent.frame using the `enclose` parameter in `eval`.